### PR TITLE
msmnile: allow hal_sensors to write to proximity and light nodes

### DIFF
--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -1,1 +1,4 @@
 /dev/sunwave_fp    u:object_r:fingerprint_device:s0
+
+/sys/devices/virtual/proximity/proximity(/.*)?		u:object_r:sysfs_sensors:s0
+/sys/devices/virtual/light/light(/.*)?		        u:object_r:sysfs_sensors:s0


### PR DESCRIPTION
avc: denied { read write } for name="enable" dev="sysfs" ino=67022 scontext=u:r:hal_sensors_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0